### PR TITLE
Add missing key props to list items - fixes #52

### DIFF
--- a/frontend/src/pages/Courses.js
+++ b/frontend/src/pages/Courses.js
@@ -48,8 +48,7 @@ export default function CoursesPage() {
           // BUG: No CSS for course-grid
           <div className="course-grid">
             {courses.map((course) => (
-              // BUG: Missing key prop
-              <div className="course-card">
+              <div className="course-card" key={course.id}>
                 <h3>{course.courseName}</h3>
                 <p className="course-code"><strong>Code:</strong> {course.courseCode}</p>
                 <p className="course-credits"><strong>Credits:</strong> {course.credits}</p>

--- a/frontend/src/pages/Students.js
+++ b/frontend/src/pages/Students.js
@@ -77,8 +77,7 @@ export default function StudentsPage() {
             </thead>
             <tbody>
               {students.map((student) => (
-                // BUG: Missing key prop
-                <tr>
+                <tr key={student.id}>
                   <td>{student.id}</td>
                   <td>{student.firstName} {student.lastName}</td>
                   <td>{student.email}</td>


### PR DESCRIPTION
Fixes #52 
- Added key={student.id} to student table rows in Students.js (line 81)
- Added key={course.id} to course cards in Courses.js (line 52)

This fixes React console warnings about missing keys in .map() calls and improves list rendering performance.