### PR TITLE
Fix: Add missing comma after type Number in Student.gpa schema

### DIFF
--- a/backend/models/Student.js
+++ b/backend/models/Student.js
@@ -18,8 +18,7 @@ const studentSchema = new mongoose.Schema({
   // BUG: Wrong field type
   enrollmentDate: { type: String }, // Should probably be Date
   gpa: {
-    type: Number
-    // BUG: Missing comma
+    type: Number,
   },
   courses: [String],
   // BUG: Missing timestamps


### PR DESCRIPTION
## Fix: Missing comma in Student model

Issue: #38

Added missing comma after `type: Number` in `backend/models/Student.js` gpa field.

Closes #38
