### PR TITLE
Fix: Add missing colon in Course schema required field

### DIFF
--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -11,7 +11,7 @@ const courseSchema = new mongoose.Schema({
   },
   courseName: {
     type: String,
-    required :true // BUG: Missing colon (:)
+    required: true
   },
   credits: {
     type: Number,

--- a/backend/models/Student.js
+++ b/backend/models/Student.js
@@ -18,8 +18,7 @@ const studentSchema = new mongoose.Schema({
   // BUG: Wrong field type
   enrollmentDate: { type: String }, // Should probably be Date
   gpa: {
-    type: Number
-    // BUG: Missing comma
+    type: Number,
   },
   courses: [String],
   // BUG: Missing timestamps


### PR DESCRIPTION
## Fix: Add missing colon in Course schema required field

Issue: #37

Changed `required :true` to `required: true` in backend/models/Course.js

Closes #37
